### PR TITLE
Add Bernstein — multi-agent orchestrator for CLI coding agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -904,6 +904,23 @@ Command-line tools for AI-assisted coding in your terminal.
 
 ---
 
+#### [Bernstein](https://bernstein.run)
+
+**Models:** Any CLI agent's model (Claude Sonnet 4.6, GPT-5, Gemini 2.5 Pro, local via Ollama, etc.)
+- Open-source (Apache 2.0) multi-agent orchestrator that runs 18 CLI coding agents in parallel — Claude Code, Codex, OpenAI Agents SDK, Cursor, Aider, Gemini CLI, Amp, Cody, Continue, Goose, Kilo, Kiro, Ollama, OpenCode, Qwen, IaC, Cloudflare, plus a generic CLI wrapper
+- Deterministic Python scheduler — no LLM in the coordination loop, runs are reproducible and auditable
+- Git worktree isolation per agent enables parallel edits without collisions
+- Janitor verifies outputs against quality gates (tests pass, files exist, lints clean) before merging to main
+- HMAC-chained audit trail for bit-identical replay
+- MCP server mode and A2A protocol support
+- BYOK only — uses whatever API keys the underlying CLI agent needs; no credit card required
+- ~9K monthly PyPI downloads
+- **Install:** `pipx install bernstein` (also `pip`, `uv`, `brew`, `dnf copr`, `npx bernstein-orchestrator`)
+
+**[GitHub](https://github.com/chernistry/bernstein)** | **[Website](https://bernstein.run)** | **[Docs](https://bernstein.readthedocs.io/)**
+
+---
+
 ### CLI Tools with Basic Models
 
 #### [Claude Code](https://www.anthropic.com/claude-code)


### PR DESCRIPTION
## Summary

Adds **Bernstein** (`bernstein.run`) to *CLI Tools with Pro-Grade Models*. Bernstein is an open-source (Apache 2.0) multi-agent orchestrator that runs 17 CLI coding agents in parallel — Claude Code, Codex, Cursor, Aider, Gemini CLI, Amp, Cody, Continue, Goose, Kilo, Kiro, Ollama, OpenCode, Qwen, IaC, Cloudflare, plus a generic CLI wrapper. Many of these are already listed in this section individually; Bernstein is the meta-tool that runs them together without coordination conflicts.

## What makes it a fit for this list

- **Open-source, Apache 2.0.** No credit card, no sign-up, no tier gates.
- **BYOK.** Uses whatever API keys the underlying CLI agent already needs. Cost goes straight to the provider, not through a middleman.
- **~9K monthly PyPI downloads**, 140+ GitHub stars, actively maintained.
- **Install:** `pipx install bernstein` (also `pip`, `uv`, `brew`, `dnf copr`, `npx`).
- **Free tier = the whole tool.** There is no paid tier; the hosted Cloudflare runtime is optional and opt-in.

## Contribution checklist

- [x] Verified the tool is active and free (published 2026, last release this week)
- [x] Specific rate limits: N/A (BYOK, limits come from the underlying provider)
- [x] Noted credit card: not required
- [x] No affiliate links
- [x] Matches the existing markdown format (mirrors the RooCode / Kilo Code / Goose style directly above and around)
- [x] Did not remove any existing entries

## Placement rationale

The section already lists single-agent CLIs (Claude Code, Codex, Aider, Goose, etc.). Bernstein is the meta-layer that runs those in parallel. It could also live under *Agentic Workflow Platforms*, but that section is visual/no-code (Make, n8n, Gumloop), and Bernstein is a developer CLI, so *CLI Tools with Pro-Grade Models* is the closer fit.

Happy to move it, split it into a new subsection, or trim the entry if you'd prefer a shorter form.

## Links

- GitHub: https://github.com/chernistry/bernstein
- Website: https://bernstein.run
- Docs: https://bernstein.readthedocs.io/