### PR TITLE
Add Prompt Template Linter to AI Evaluation Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -1818,8 +1818,8 @@ Benchmark your models before production.
 | **RAGAS** | RAG evaluation | Open source |
 | **DeepEval** | LLM unit testing | Open source |
 | **Arize Phoenix** | Observability | Generous free tier |
-| **Weights & Biases** | Experiment tracking | Academic free |
-
+| **Weights & Biases** | Experiment tracking | Academic free | 
+| **[Prompt Template Linter](https://uatgpt.com/tools/prompt-linter/)** | Lint system prompts — 12 failure classes, 0-100 score | Free, client-side |
 ---
 
 ## 📐 Structured Output Tools


### PR DESCRIPTION
Adds Prompt Template Linter to the 📊 AI Evaluation Tools table.

What it does:
- Scores a pasted system prompt across 12 structural failure classes (missing role, ambiguous verbs, missing output format, no examples, too many examples, negative-only direction, conflicting instructions, missing scope, missing fallback, token bloat, repeated phrases, format drift).
- Returns a 0-100 quality score with per-dimension breakdown (role, task-clarity, format, examples, constraints, fallback).
- 5 impact-ranked recommendations per audit.
- Task-type-aware across 5 types. 3 demos. Runs client-side, no signup.

Fit for AI Evaluation Tools:
- Sits next to Promptfoo (prompt testing) and DeepEval (LLM unit testing) — covers the pre-test prompt-quality-audit step.
- Inclusion criteria match: tool developers actually use in pre-production, generous free tier (fully free, client-side).

Transparency:
- I used an AI assistant to help draft this PR description. The tool itself, its code, and its UX are hand-built and client-side.

Happy to adjust wording, section placement, or column phrasing if preferred.