### PR TITLE
Add OfoxAI to Free LLM API Providers section

### DIFF
--- a/README.md
+++ b/README.md
@@ -292,6 +292,16 @@ Ready-made combinations for different use cases. Copy-paste these configurations
 
 ---
 
+#### [OfoxAI](https://ofox.ai)
+
+Unified API gateway for 100+ LLMs. OpenAI and Anthropic SDK-compatible. China-friendly with Hong Kong direct access (100-300ms latency). No monthly fees, pay per token.
+
+**Limits:** Not published | **1 free model**
+
+- [GLM-4.7-Flash](https://ofox.ai/models/z-ai/glm-4.7-flash:free) (200K context, 128K output, $0/M input, $0/M output)
+
+---
+
 #### [Google AI Studio](https://aistudio.google.com)
 
 Data is used for training when used outside UK/CH/EEA/EU.


### PR DESCRIPTION
## Add OfoxAI

**Website:** https://ofox.ai

OfoxAI is a unified API gateway for 100+ LLMs. It offers a genuinely free model:

- **z-ai/glm-4.7-flash:free** (GLM-4.7-Flash by Zhipu AI)
  - Input: $0/M tokens
  - Output: $0/M tokens
  - Context: 200K, Max output: 128K
  - Base URL: `https://api.ofox.ai/v1`

**Why it belongs here:**
- Permanent free model (not trial credits)
- OpenAI and Anthropic SDK-compatible
- China-friendly with Hong Kong direct access
- No credit card required for free model

Rate limits are not published; marked as such in the entry.