### PR TITLE
Add awesome-ai-startups to Related Resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -1870,6 +1870,7 @@ No affiliation with any vendor. All trademarks belong to their owners. Informati
 - [mnfst/awesome-free-llm-apis](https://github.com/mnfst/awesome-free-llm-apis) (2.1k ⭐) - Permanent free LLM API tiers
 - [inmve/free-ai-coding](https://github.com/inmve/free-ai-coding) (648 ⭐) - Pro-grade AI coding tools comparison
 - [Coding with AI](https://coding-with-ai.dev/) - Practical techniques for coding with LLMs
+- [nowork-studio/awesome-ai-startups](https://github.com/nowork-studio/awesome-ai-startups) - A curated list of bootstrapped, pre-seed, and angel-funded AI products built by independent founders
 
 ### Research Methodology
 


### PR DESCRIPTION
Adds one entry to the **Related Resources** section:

- [nowork-studio/awesome-ai-startups](https://github.com/nowork-studio/awesome-ai-startups) - A curated list of bootstrapped, pre-seed, and angel-funded AI products built by independent founders

Format matches existing entries in the section (simple bullet + short description). Star count omitted since the repo is new and the convention is approximate (k-rounded) star counts for established repos.