### PR TITLE
Add Punch Needle Generator to Creative & Multimedia Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -1242,6 +1242,7 @@ Professional-grade content creation with generous free tiers.
 | [Suno AI](https://suno.ai) | Music | 50 credits/day (~10 tracks) | Complete songs with vocals and instruments |
 | [ElevenLabs](https://elevenlabs.io) | Voice | Basic Free | Realistic voice cloning |
 | [Canva AI](https://canva.com) | Design | Robust free tier | AI design assets, brochures, short videos |
+| [Punch Needle Generator](https://www.punchneedle.co.il/en) | Embroidery patterns | 5 patterns/day | AI-generated punch needle patterns with color-coded yarn maps; PDF/PNG/SVG export |
 
 ---
 


### PR DESCRIPTION
Adds Punch Needle Generator under **Additional 2026 AI Tools > Creative & Multimedia Tools**.

- **Name:** Punch Needle Generator
- **URL:** https://www.punchneedle.co.il/en
- **Free tier:** 5 patterns/day
- **What it does:** AI-generated punch needle embroidery patterns with color-coded yarn maps; PDF/PNG/SVG export.

Single entry, follows the table format of the section. I'm the maintainer of the tool.