### PR TITLE
Add CoderPlan to API Providers for AI Coding Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -1036,6 +1036,17 @@ These services provide API access to coding-optimized models for tools like Curs
 
 **[Pricing](https://www.cerebras.ai/pricing)** | **[API Docs](https://inference-docs.cerebras.ai/)** | **[Integrations](https://inference-docs.cerebras.ai/integrations/)**
 
+### [CoderPlan](https://coderplan.ai/)
+
+- **Pay-as-you-go API gateway** — ~70% below official pricing
+- Claude, GPT-4o, Gemini, DeepSeek, Grok and 50+ models
+- OpenAI-compatible API (works with Claude Code, Cursor, Cline, Codex CLI)
+- ¥10 (~$1.5) minimum top-up — Alipay, WeChat Pay
+- HK/Singapore nodes — low latency from China, no VPN required
+
+**[Pricing](https://coderplan.ai/pricing)** | **[Docs](https://docs.coderplan.ai)** | **[API Status](https://status.coderplan.ai)**
+
+---
 ---
 
 ## Paid Tiers Comparison


### PR DESCRIPTION
## Summary

Added [CoderPlan](https://coderplan.ai) to the **API Providers for AI Coding Tools** section.

### What is CoderPlan?

CoderPlan is a pay-as-you-go LLM API gateway for developers in China and Asia-Pacific:

- **OpenAI-compatible API** — works with Claude Code, Cursor, Cline, Codex CLI, Continue.dev
- **50+ models** — Claude, GPT-4o, Gemini, DeepSeek, Grok
- **~70% below official pricing** — ¥10 (~$1.5) minimum top-up
- **China-optimized** — Alipay/WeChat Pay, HK/Singapore nodes, no VPN required

### Why add it?

The repo focuses on tools developers *actually* use with generous/affordable pricing. CoderPlan fills a gap: it is the most affordable way for China-based developers to access Claude Code and other AI coding tools via a unified API. It complements OpenRouter (global) by serving the China/APAC market specifically.

### Checklist
- [x] Entry follows existing format (### heading, bullet points, pricing/docs links)
- [x] Placed in correct section (API Providers for AI Coding Tools)
- [x] Not a personal/expensive project — genuinely useful free tier/low cost