### PR TITLE
Add Auferet (memory-first AI game master)

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,6 +162,7 @@ If this repo helped you build something or saved you money:
 | Tool | Starting Price | Free Tier | Features | Credit Card |
 |------|----------------|-----------|-----------|-------------|
 | [PrixAI](https://www.prixai.xyz) | Free / $10 paid plan | Free trial available | Unlimited reviews Auto-fix PRs, issue planning | No |
+[Auferet](https://auferet.com) - AI game master with persistent memory for your characters and uploaded lore; solo or multiplayer, with 5e and Pathfinder 2e modes.
 | [Bito](#bito) | Free / $25 paid plans | Free trial available | AI PR reviews/Unlimited reviews | No |
 | [Sourcery](#sourcery) | ~$12/month | Free trial available | Code quality reviews | No |
 

--- a/README.md
+++ b/README.md
@@ -162,7 +162,7 @@ If this repo helped you build something or saved you money:
 | Tool | Starting Price | Free Tier | Features | Credit Card |
 |------|----------------|-----------|-----------|-------------|
 | [PrixAI](https://www.prixai.xyz) | Free / $10 paid plan | Free trial available | Unlimited reviews Auto-fix PRs, issue planning | No |
-[Auferet](https://auferet.com) - AI game master with persistent memory for your characters and uploaded lore; solo or multiplayer, with 5e and Pathfinder 2e modes.
+| [Auferet](https://auferet.com) | AI game master that remembers your world: persistent memory for characters, places, and lore you upload; solo or multiplayer, 5e & Pathfinder 2e | — | — | — |
 | [Bito](#bito) | Free / $25 paid plans | Free trial available | AI PR reviews/Unlimited reviews | No |
 | [Sourcery](#sourcery) | ~$12/month | Free trial available | Code quality reviews | No |
 


### PR DESCRIPTION
Adds Auferet, an AI game master for solo and multiplayer roleplaying games. It keeps your characters, world, and events in persistent memory and reads lore you upload, so the story stays consistent across long campaigns. Runs 5e and Pathfinder 2e, plays in the browser and on Android, free to start.

Website: https://auferet.com
