### PR TITLE
Add cv.cm/v to Video Generation APIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1250,6 +1250,7 @@ Text-to-video and image-to-video generation. Hot area in 2026.
 | **Kling** | Kuaishou | Excellent | 2-10 minutes | Limited | Long-form, Chinese |
 | **Hailuo AI** | MiniMax | Good | 6 seconds | Free tier | Character consistency |
 | **Stable Video Diffusion** | Stability | Good | 4 seconds | Local | Open, flexible |
+| **cv.cm/v** | Cloud Clipboard | Excellent | 2K, multi-shot up to 60s | 100 credits, no card | Queue-free Seedance 2.0, REST API, no signup |
 
 ### Video API Pricing (approximate)
 


### PR DESCRIPTION
Adds **cv.cm/v** to the Video Generation APIs table.

| Field | Value |
|-------|-------|
| **Tool** | [cv.cm/v](https://cv.cm/v) (Cloud Clipboard AI Studio) |
| **Category** | Video generation (text-to-video / image-to-video) |
| **Free Tier** | 100 free credits on signup |
| **Models** | Queue-free, full-power Seedance 2.0 (also gpt-image-2 / Seedream for images) |
| **Credit Card Required?** | No |
| **Extras** | REST API, node-graph canvas, no signup required to try |
| **Last Verified** | 2026-06-30 |

One table row added, matching the existing column format. Fits the repo's free-tier / no-credit-card focus.