### PR TITLE
Add NovAI to Providers with Trial Credits ($2 signup, Chinese models …

### DIFF
--- a/README.md
+++ b/README.md
@@ -454,6 +454,7 @@ AI gateway with curated models. Free models may use data for improvement.
 | [Hyperbolic](https://app.hyperbolic.ai/) | $1 | Permanent | DeepSeek, Llama, Qwen, GPT-OSS |
 | [SambaNova Cloud](https://cloud.sambanova.ai/) | $5 | 3 months | Llama, Qwen, DeepSeek |
 | [Scaleway](https://console.scaleway.com/generative-api/models) | 1M tokens | Permanent | DeepSeek, Llama, Mistral, Gemma |
+| [NovAI](https://aiapi-pro.com/) | $2 | Signup | OpenAI-compatible relay for Chinese models (DeepSeek, Qwen, GLM, Kimi, MiniMax) + Doubao image/video; no card required, pay-as-you-go after [verify] |
 
 ### Additional Free API Providers
 


### PR DESCRIPTION
**Tool:** [NovAI](https://aiapi-pro.com/) — added to **Providers with Trial Credits**.

- **Category:** API Provider (OpenAI-compatible relay)
- **Credits:** $2 credit on signup
- **Models:** Chinese frontier models (DeepSeek, Qwen, GLM/Zhipu, Kimi/Moonshot, MiniMax) + Doubao image (Seedream) & video (Seedance) on the same endpoint
- **Credit card required:** No (start on the free signup credit)
- **Pricing:** https://aiapi-pro.com/pricing (per-token pay-as-you-go after the credit)
- **Last verified:** 2026-07-20

Marked the credit duration [verify] since I couldn't confirm whether the $2 signup credit expires — happy to correct.

_Disclosure: I'm affiliated with NovAI (vendor self-submission). No affiliate/sponsored links; entry uses specific numbers and links to the official pricing page per CONTRIBUTING.md. Please adjust wording or drop it if you'd prefer._