### PR TITLE
Add Orkas to open source tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -1136,6 +1136,7 @@ Professional-grade content creation with generous free tiers.
 | [Zed](https://zed.dev) | AI IDE | 50 AI prompts/month, native performance, high speed |
 | [Void IDE](https://voideditor.com/) | Agent-first IDE | Multi-agent frontend/backend/testing | Preview, free tier |
 | [MemoryPalace](https://github.com/milla-jovovich/mempalace) | AI Memory System | 96.6% LongMemEval — memory palace technique for AI conversations | Free, open source |
+| [Orkas](https://orkas.ai?source=gh-freeai) | Multi-Agent AI Workspace | Free, MIT-licensed desktop app with local data and BYO model keys. [Source](https://github.com/Orkas-AI/Orkas) |
 
 ---
 


### PR DESCRIPTION
## Summary
- add Orkas to the Open Source & Local Tools section
- link the official website with a distinct source tag and the MIT-licensed repository

## Why it fits
Orkas is an open-source, local-first desktop AI workforce. A Commander coordinates specialist agents in parallel or sequence through one chat, and users bring their own model keys.

## Verification
- Official site: https://orkas.ai?source=gh-freeai
- Source: https://github.com/Orkas-AI/Orkas