### PR TITLE
Add GPTGeminiGrok.AI to AI Chat Platforms

### DIFF
--- a/README.md
+++ b/README.md
@@ -677,6 +677,7 @@ General-purpose chat interfaces with free tiers.
 | [Claude](https://claude.ai) | **Claude Sonnet/Haiku** | Technical reasoning | ~30 msgs/5h |
 | [Grok](https://grok.com) | **Grok 4.2** | Aurora 2 images, voice | 15 msgs/12hr |
 | [Mistral Le Chat](https://chat.mistral.ai) | **Mistral Medium 3** | Structured output | Fewer integrations |
+| [GPTGeminiGrok.AI](https://trygrokai.asia/) | **GPT, Gemini, Grok, Claude** | Multi-model chat and AI image workflows | 10 requests/day; account required |
 
 ---
 


### PR DESCRIPTION
Adds [GPTGeminiGrok.AI](https://trygrokai.asia/) to the Additional 2026 AI Chat Platforms table.\n\nVerified access details:\n- Model families: GPT, Gemini, Grok, and Claude\n- Capabilities: multi-model chat and AI image workflows\n- Free limit: 10 requests per day\n- Requirement: an account is required\n\nDisclosure: I am the creator of the submitted product. The PR adds one table row, uses the canonical URL with no affiliate parameters, and changes no existing content.