### PR TITLE
Add agent-qa

### DIFF
--- a/README.md
+++ b/README.md
@@ -868,6 +868,17 @@ Command-line tools for AI-assisted coding in your terminal.
 - **Self-Correction & Lint loops**: Features tight compilation/lint integration to verify code sanity and fix compiler/linter issues iteratively.
 - **Open-source & Free**: Developed by the Advanced Agentic Coding team.
 
+#### [agent-qa](https://github.com/vostride/agent-qa)
+
+**Models:** OpenAI- and Anthropic-compatible endpoints, Gemini, and local models
+- Self-hosted QA CLI and dashboard with no agent-qa usage cap
+- No credit card required when paired with local models
+- Bring your own model/provider; provider costs and rate limits apply
+- MCP server and skills for Claude Code and Codex
+- **Install:** `npm install -D agent-qa && npx agent-qa init`
+
+**[Documentation](https://vostride.com/docs/agent-qa)** | **[License](https://github.com/vostride/agent-qa/blob/main/LICENSE.md)** | **Last verified:** 2026-08-16
+
 ---
 
 ## API Providers for AI Coding Tools


### PR DESCRIPTION
## Summary

Adds agent-qa to **Free Coding Assistants (CLI)** with the model, pricing, setup, documentation, and license details requested by the contribution guide.

agent-qa is the self-improving QA agent for software teams. It runs natural-language web and mobile tests through a CLI and dashboard, and integrates with coding agents through MCP and Agent Skills.

## Free-tier details

- The self-hosted agent-qa runtime has no agent-qa usage cap.
- It can run without a credit card when paired with a local model.
- Users bring their own model or provider, so external provider costs and limits may apply.
- The entry includes a copyable npm install command and the date it was verified.

## Validation

- Repository, documentation, and license links return HTTP 200.
- The project was not already listed or proposed.
- Markdown structure and `git diff --check` pass.

Project disclosure: this submission is for agent-qa itself. The current FSL-1.1-ALv2 license is source-available/fair-code and converts to Apache-2.0 after two years.
