### PR TITLE
Add OpenClaw AI — free no-key OpenAI-compatible gateway

### DIFF
--- a/README.md
+++ b/README.md
@@ -466,6 +466,7 @@ AI gateway with curated models. Free models may use data for improvement.
 | [Chutes AI](https://chutes.ai) | 4 | Free community GPU-powered | `CHUTES_API_KEY` |
 | [DeepInfra](https://deepinfra.com/login) | 4 | 200 concurrent requests | `DEEPINFRA_API_KEY` |
 | [Replicate](https://replicate.com/account/api-tokens) | 2 | 6 req/min (no payment), up to 3K RPM with payment | `REPLICATE_API_TOKEN` |
+| [OpenClaw AI](https://ai.trxenergy.vip) | 7 | 50,000 sats/day/IP (no key) | (none required) |
 
 ---
 


### PR DESCRIPTION
Adds OpenClaw AI to Additional Free API Providers: a self-hosted OpenAI-compatible inference gateway. No account, no API key, no credit card — every IP gets 50,000 sats of free credits per day (L402), then pay-per-token over Lightning. 7 open-weight models (deepseek-r1, qwen3.6-27b, codellama-13b, llama3, llama2, openchat-7b, qwen2.5-1.5b). Base URL: https://ai.trxenergy.vip/v1