### PR TITLE
Add HelloGen to Creative & Multimedia Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -1086,6 +1086,7 @@ Professional-grade content creation with generous free tiers.
 | [Suno AI](https://suno.ai) | Music | 50 credits/day (~10 tracks) | Complete songs with vocals and instruments |
 | [ElevenLabs](https://elevenlabs.io) | Voice | Basic Free | Realistic voice cloning |
 | [Canva AI](https://canva.com) | Design | Robust free tier | AI design assets, brochures, short videos |
+| [HelloGen](https://hellogen.ai) | Image + Video | Unlimited images, no watermark | Multiple image/video models in one place, price quoted before each render |
 
 ---
 


### PR DESCRIPTION
Adds one row to **Additional 2026 AI Tools → Creative & Multimedia Tools**.

```
| [HelloGen](https://hellogen.ai) | Image + Video | Unlimited images, no watermark | Multiple image/video models in one place, price quoted before each render |
```

Filling in the fields from CONTRIBUTING.md:

| Field | Value |
|---|---|
| **Tool Name** | [HelloGen](https://hellogen.ai) |
| **Category** | Creative / Multimedia (image + video generation) |
| **Free Tier Details** | Unlimited image generation on a free account, no watermark, commercial license on output. Video is credit-based, not free — credit packs start at $4.90. |
| **Models Available** | Image: Z-Image Turbo, Qwen Image Edit, GPT Image 2, Nano Banana (Lite/2/Pro), Seedream (4.5 / 5.0 Lite / 5.0 Pro). Video: Seedance 2, Veo 3.1, Kling 3.0, MiniMax H3. |
| **Credit Card Required?** | No — free image tier needs no card |
| **Pricing Page** | https://hellogen.ai/pricing/ |
| **Last Verified** | 2026-08-30 |

Two things that seem relevant to a list about free and low-cost tools: the assistant picks the model and **shows the price before it renders**, and **failed generations aren't charged** — so the credit-based half is predictable rather than a black box.

Listed under Creative & Multimedia rather than the Image/Video API tables because it is an end-user studio, not an API.