### PR TITLE
Add WSUP AI: Free AI Character Chat

### DIFF
--- a/README.md
+++ b/README.md
@@ -677,6 +677,7 @@ General-purpose chat interfaces with free tiers.
 | [Claude](https://claude.ai) | **Claude Sonnet/Haiku** | Technical reasoning | ~30 msgs/5h |
 | [Grok](https://grok.com) | **Grok 4.2** | Aurora 2 images, voice | 15 msgs/12hr |
 | [Mistral Le Chat](https://chat.mistral.ai) | **Mistral Medium 3** | Structured output | Fewer integrations |
+| [WSUP AI](https://wsupai.app/) | Character chat | Free AI character chat, no sign up, SFW only | Unlimited free |
 
 ---
 


### PR DESCRIPTION
## Summary
Add **WSUP AI: Free AI Character Chat** to the Additional 2026 AI Chat Platforms section.

## Product
- **Name:** WSUP AI: Free AI Character Chat
- **URL:** https://wsupai.app/
- **Description:** Free AI character chat in the browser — talk to AI characters with no sign up. SFW only.

## Affiliation
I am affiliated with WSUP AI / Ownland (maintainer submitting this listing).

## Notes
- One product per PR
- Matched neighbor formatting in the target section
- SFW-only character chat product
