### PR TITLE
Add YYLO to free AI coding tools list

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,6 +183,7 @@ If this repo helped you build something or saved you money:
 | [Goose](#goose) | Bring your own keys | Unlimited (BYOK) | No |
 | [OhMyPi](#ohmypi) | Bring your own keys | Unlimited (BYOK) | No |
 | [Antigravity](#antigravity) | BYOK / Local model fallback | Unlimited (BYOK / 100% Offline) | No |
+| [YYLO](#yylo) | Bring your own agents (Pi, Codex subagents) | Unlimited (MIT open source) | No |
 
 ### What Qualifies as "Pro-Grade"?
 
@@ -867,6 +868,17 @@ Command-line tools for AI-assisted coding in your terminal.
 - **AI-Powered Data Sorting**: Auto-ingests messy, raw, lowercase brain dumps and sorts them into logical categories, subcategories, and structured spreadsheet columns/rows.
 - **Self-Correction & Lint loops**: Features tight compilation/lint integration to verify code sanity and fix compiler/linter issues iteratively.
 - **Open-source & Free**: Developed by the Advanced Agentic Coding team.
+
+#### [YYLO](https://github.com/yylo-dev/yylo)
+
+**Models:** Bring your own coding agents — orchestrates Pi and Codex subagents (model access follows each agent's own plan and keys)
+- **Free and open source (MIT):** no paid tier, no credit card, unlimited use of the tool itself
+- **Command-line orchestrator for coding agents, repeatable workflows, and receipt-backed repository changes** with typed task, validation, merge, and release-readiness boundaries
+- **Dedicated branch/worktree per task:** `task start` freezes the protected target SHA, creates a dedicated branch/worktree, and completes dependency hydration before work begins
+- **Merge queue owns risk-based review:** risk-scaled reviewers on one frozen candidate, with hash-linked receipts and provenance for every change
+- **Install:** `npm install --global '@yylo/cli@latest'`
+
+**[GitHub](https://github.com/yylo-dev/yylo)** | **[npm](https://www.npmjs.com/package/@yylo/cli)**
 
 ---
 


### PR DESCRIPTION
## Summary

Adds **[YYLO](https://github.com/yylo-dev/yylo)** to the CLI Coding Tools section (entry + comparison-table row), following the format of the recently added [Antigravity](#antigravity) entry.

YYLO is a free, MIT-licensed command-line orchestrator for coding agents: each task runs in a dedicated branch/worktree behind typed task, validation, merge, and release-readiness boundaries, and a merge queue owns risk-based review. Model access is bring-your-own — it orchestrates **Pi and Codex** subagents, so it sits naturally in the same band as RooCode/Goose/OhMyPi/Antigravity (BYOK rows).

## CONTRIBUTING checklist

- [x] I verified the free tier still exists — the tool itself is fully free and open source (MIT); there is no paid tier
- [x] I checked the official pricing page — no pricing page exists (OSS); GitHub + npm linked instead
- [x] I included specific rate limits — no limits on the tool itself; model usage follows each orchestrated agent's own plan/keys (BYOK, stated in the entry)
- [x] I noted if a credit card is required — **No**
- [x] I added `[verify]` to any uncertain claims — no uncertain claims (all wording quoted from the project README)
- [x] I followed the existing markdown format — `#### [Name](repo)` entry with `**Models:**` line + bullets + links, plus a comparison-table row, mirroring the Antigravity entry
- [x] I didn't remove any existing tools — +12/−0, README.md only

Last verified: 2026-09-06 (live repo + npm).

## Why it fits this list

- Category: **CLI Tool** (free tier: the whole tool — MIT, unlimited)
- The list's BYOK band (RooCode, Goose, OhMyPi, Antigravity) is exactly YYLO's model: bring your own agents/keys, the tool itself costs nothing
- Pi is already listed here (OhMyPi row) — YYLO is the orchestration layer over Pi/Codex-class CLIs

## Adoption / activity

- 57 GitHub stars, MIT, pushed daily since January 2026
- Installable via npm: [`@yylo/cli`](https://www.npmjs.com/package/@yylo/cli) (~560 downloads/month)

## Disclosure

I'm on the team that builds YYLO, and this PR was prepared with AI assistance then reviewed by me — happy to adjust wording or placement (e.g. if you'd prefer it under a different section). If a young open-source tool doesn't meet the bar here yet, feel free to close; I won't resubmit until the project has stronger traction.
